### PR TITLE
Fix compilation errors in the MSYS2 shell environment.

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -18,7 +18,7 @@
 #define UNIX_PATH_MAX UNIX_PATH_LEN
 #endif
 
-#ifdef __MSYS__
+#if defined(__MSYS__) && !defined(__NEWLIB__)
 
 #include <unistd.h>
 #include <errno.h>
@@ -123,6 +123,6 @@ cygwin_conv_path (unsigned what, const void *from, void *to, size_t size)
 
 #include <err.h>
 
-#endif
+#endif // defined(__MSYS__) && !defined(__NEWLIB__)
 
 #endif /* __COMPAT_H__ */

--- a/winpgntc.h
+++ b/winpgntc.h
@@ -15,11 +15,11 @@
 
 #define AGENT_MAX_MSGLEN  8192
 
-#ifdef __MSYS__
+#if defined(__MSYS__) && !defined(__NEWLIB__)
 // MSYS doesn't have stdint.h or uint32_t,
 // but its ntohl wants unsigned long anyway.
 typedef unsigned long uint32_t;
-#endif
+#endif // defined(__MSYS__) && !defined(__NEWLIB__)
 
 extern void agent_query(void *buf);
 


### PR DESCRIPTION
This pull request fixes #29 by distinguishing between MSYS and MSYS2 using the __NEWLIB__ preprocessor symbol as suggested by the original author Josh Stone. After this change, ssh-pageant compiles without problems in the MSYS2 shell environment using msys/gcc. The MSYS2 openssh package is then able to use the keys stored in Pageant via ssh-pageant.