### PR TITLE
README: Add MSYS2 installation instructions using pacman

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ the [32-bit][32-bit-msys] release for MSYS.
 
         $ cp ssh-pageant.1 /usr/share/man/man1/
 
+Alternatively, if you are running [MSYS2](https://msys2.github.io/), just run `pacman -S ssh-pageant`.
 
 ## Usage
 


### PR DESCRIPTION
There is now an MSYS2 package available at

https://github.com/Alexpux/MSYS2-packages/tree/master/ssh-pageant-git

Binaries are available at

http://sourceforge.net/projects/msys2/files/REPOS/MSYS2/i686/
http://sourceforge.net/projects/msys2/files/REPOS/MSYS2/x86_64/