### PR TITLE
fix: prevent crash when result of SendMessage is 0

### DIFF
--- a/winpgntc.c
+++ b/winpgntc.c
@@ -114,10 +114,10 @@ agent_query(void *buf)
                 return;
         }
 
-        if (psd)
-            LocalFree(psd);
-        if (usersid)
-            free(usersid);
+        /* LocalFree and free are fine with NULL, so null checks aren't
+          * necessary. */
+        LocalFree(psd);
+        free(usersid);
 
     }
 

--- a/winpgntc.c
+++ b/winpgntc.c
@@ -107,14 +107,18 @@ agent_query(void *buf)
             UnmapViewOfFile(p);
             CloseHandle(filemap);
             LocalFree(psd);
+            psd = NULL;
             free(usersid);
-
+            usersid = NULL;
             if (id > 0)
                 return;
         }
 
-        LocalFree(psd);
-        free(usersid);
+        if (psd)
+            LocalFree(psd);
+        if (usersid)
+            free(usersid);
+
     }
 
     static const char reply_error[5] = { 0, 0, 0, 1, SSH_AGENT_FAILURE };


### PR DESCRIPTION
openssh 8.9 introduces feature "SSH agent restriction", which
means protocol extension (SSH_AGENTC_EXTENSION) will be used
(https://www.openssh.com/agent-restrict.html#limitations).

When connecting to older pageant with openssh 8.9 client,
the message with type SSH_AGENTC_EXTENSION can't be processed
by pageant, thus SendMessage returns 0, in which case
`psd` and `usersid` is likely to be freed twice in the code,
causing crash.

This commit fixes this.